### PR TITLE
refactor: implement lazy loading to prevent hot reload blocking

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "type": "module",
   "scripts": {
     "prepare": "husky",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "test:all": "bun run --filter '*' test",
+    "build:all": "bun run --filter '*' build"
   },
   "workspaces": {
     "packages": [

--- a/packages/config/index.ts
+++ b/packages/config/index.ts
@@ -6,6 +6,25 @@ import { dirname, join } from "path";
 import { HOME_NAME, CONFIG_NAME } from "./src/identity";
 import { ConfigSchema, type Config, type ReturnConfig } from "./src/schema";
 
+declare global {
+  var __cognotate_config:
+    | {
+        current: ReturnConfig | undefined;
+        promise: Promise<ReturnConfig> | null;
+      }
+    | undefined;
+}
+
+const getConfigState = () => {
+  if (!globalThis.__cognotate_config) {
+    globalThis.__cognotate_config = {
+      current: undefined,
+      promise: null,
+    };
+  }
+  return globalThis.__cognotate_config;
+};
+
 export const ROOT = join(homedir(), HOME_NAME);
 export const ROOT_CONFIG = join(ROOT, "config.jsonc");
 
@@ -71,21 +90,22 @@ const loadConfig = async (): Promise<ReturnConfig> => {
   return mergedConfig;
 };
 
-let _promise: Promise<ReturnConfig> | null = null;
-let _current: ReturnConfig | undefined;
-
 const getConfig = (force = false): Promise<ReturnConfig> => {
-  if (!force && _current) return Promise.resolve(_current);
+  const state = getConfigState();
 
-  if (!_promise || force) {
-    _promise = (async () => {
+  if (!force && state.current) {
+    return Promise.resolve(state.current);
+  }
+
+  if (!state.promise || force) {
+    state.promise = (async () => {
       const cfg = await loadConfig();
-      _current = cfg;
-      _promise = null;
+      state.current = cfg;
+      state.promise = null;
       return cfg;
     })();
   }
-  return _promise;
+  return state.promise;
 };
 
 const refreshConfig = async (): Promise<ReturnConfig> => {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "module": "index.ts",
   "scripts": {
-    "build": "bun build index.ts --target=bun --outdir ./dist"
+    "build": "bun build index.ts --target=bun --outdir ./dist --metafile=./dist/meta.json --metafile-md=./dist/meta.md",
+    "test": "bun test"
   },
   "devDependencies": {
     "@types/bun": "catalog:types"

--- a/packages/config/test/config.component.test.ts
+++ b/packages/config/test/config.component.test.ts
@@ -1,0 +1,31 @@
+// packages/config/test/config.component.test.ts
+
+import { describe, it, expect, beforeEach } from "bun:test";
+import { getConfig, refreshConfig } from "../index";
+
+describe("config", () => {
+  beforeEach(() => {
+    // Reset global state before each test
+    globalThis.__cognotate_config = undefined;
+  });
+
+  it("should return a config object", async () => {
+    const config = await getConfig();
+    expect(config).toBeDefined();
+    expect(config.database).toBeDefined();
+    expect(config.database.type).toBe("sqlite");
+  });
+
+  it("should cache config and return same instance", async () => {
+    const config1 = await getConfig();
+    const config2 = await getConfig();
+    expect(config1).toEqual(config2);
+  });
+
+  it("should refresh config and return new instance", async () => {
+    const config1 = await getConfig();
+    const config2 = await refreshConfig();
+    expect(config1).not.toBe(config2);
+    expect(config2.database.type).toBe("sqlite");
+  });
+});

--- a/packages/database/index.ts
+++ b/packages/database/index.ts
@@ -4,8 +4,23 @@ import { getConfig } from "@cognotate/config";
 import { PrismaClient } from "./generated/prisma/client";
 
 declare global {
-  var __prisma: PrismaClient | undefined;
+  var __cognotate_prisma:
+    | {
+        current: PrismaClient | undefined;
+        promise: Promise<PrismaClient> | null;
+      }
+    | undefined;
 }
+
+const getPrismaState = () => {
+  if (!globalThis.__cognotate_prisma) {
+    globalThis.__cognotate_prisma = {
+      current: undefined,
+      promise: null,
+    };
+  }
+  return globalThis.__cognotate_prisma;
+};
 
 const getAdapter = async () => {
   const globalConfig = await getConfig();
@@ -38,12 +53,26 @@ const genPrismaClient = async () => {
   return new PrismaClient({ adapter });
 };
 
-// Create or reuse the global prisma instance
-const prisma = globalThis.__prisma ?? (await genPrismaClient());
+const getPrisma = (force = false): Promise<PrismaClient> => {
+  const state = getPrismaState();
 
-// In development, save to global to prevent hot-reloading issues
-if (process.env.NODE_ENV !== "production") {
-  globalThis.__prisma = prisma;
-}
+  if (!force && state.current) {
+    return Promise.resolve(state.current);
+  }
 
-export { prisma };
+  if (!state.promise || force) {
+    state.promise = (async () => {
+      const prisma = await genPrismaClient();
+      state.current = prisma;
+      state.promise = null;
+      return prisma;
+    })();
+  }
+  return state.promise;
+};
+
+const refreshPrisma = async (): Promise<PrismaClient> => {
+  return getPrisma(true);
+};
+
+export { getPrisma, refreshPrisma };

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "module": "index.ts",
   "scripts": {
-    "build": "bun build index.ts --target=bun --outdir ./dist",
+    "test": "bun test",
+    "build": "bun build index.ts --target=bun --outdir ./dist --metafile=./dist/meta.json --metafile-md=./dist/meta.md",
     "db:gen": "bunx --bun prisma generate",
     "db:push": "bunx --bun prisma db push",
     "db:push:force": "bunx --bun prisma db push --force-reset",

--- a/packages/database/prisma/seed.ts
+++ b/packages/database/prisma/seed.ts
@@ -1,3 +1,3 @@
 // packages/database/prisma/seed.ts
 
-import { prisma } from "../index";
+import { getPrisma } from "../index";

--- a/packages/database/test/database.component.test.ts
+++ b/packages/database/test/database.component.test.ts
@@ -1,0 +1,43 @@
+// packages/database/test/database.component.test.ts
+import { test, describe, expect, mock, beforeEach } from "bun:test";
+import { getPrisma, refreshPrisma } from "../index";
+
+mock.module("@cognotate/config", () => ({
+  getConfig: mock(() =>
+    Promise.resolve({
+      database: { type: "sqlite", url: ":memory:" },
+    }),
+  ),
+}));
+
+describe("database", () => {
+  beforeEach(() => {
+    // Reset global state before each test
+    globalThis.__cognotate_prisma = undefined;
+  });
+
+  test("getPrisma returns PrismaClient instance", async () => {
+    const prisma = await getPrisma();
+
+    // Verify it's a PrismaClient instance
+    expect(prisma).toBeDefined();
+    expect(typeof prisma.$connect).toBe("function");
+    expect(typeof prisma.$disconnect).toBe("function");
+  });
+
+  test("getPrisma caches instance across calls", async () => {
+    const prisma1 = await getPrisma();
+    const prisma2 = await getPrisma();
+
+    // Should return the same cached instance
+    expect(prisma1).toBe(prisma2);
+  });
+
+  test("refreshPrisma creates new instance", async () => {
+    const prisma1 = await getPrisma();
+    const prisma2 = await refreshPrisma();
+
+    // Should return different instances
+    expect(prisma1).not.toBe(prisma2);
+  });
+});

--- a/packages/llm/hub.ts
+++ b/packages/llm/hub.ts
@@ -9,6 +9,25 @@ import { createXai } from "@ai-sdk/xai";
 
 type ProviderHub = ReturnType<typeof createProviderRegistry>;
 
+declare global {
+  var __cognotate_provider_hub:
+    | {
+        current: ProviderHub | undefined;
+        promise: Promise<ProviderHub> | null;
+      }
+    | undefined;
+}
+
+const getProviderHubState = () => {
+  if (!globalThis.__cognotate_provider_hub) {
+    globalThis.__cognotate_provider_hub = {
+      current: undefined,
+      promise: null,
+    };
+  }
+  return globalThis.__cognotate_provider_hub;
+};
+
 const PROVIDER_FACTORIES = {
   openai: () => createOpenAI({ apiKey: Bun.env.OPENAI_API_KEY }),
   anthropic: () => createAnthropic({ apiKey: Bun.env.ANTHROPIC_API_KEY }),
@@ -27,21 +46,22 @@ const loadHub = async (): Promise<ProviderHub> => {
   return createProviderRegistry(Object.fromEntries(entries));
 };
 
-let _promise: Promise<ProviderHub> | null = null;
-let _current: ProviderHub | undefined;
-
 const getProviderHub = (force = false): Promise<ProviderHub> => {
-  if (!force && _current) return Promise.resolve(_current);
+  const state = getProviderHubState();
 
-  if (!_promise || force) {
-    _promise = (async () => {
+  if (!force && state.current) {
+    return Promise.resolve(state.current);
+  }
+
+  if (!state.promise || force) {
+    state.promise = (async () => {
       const hub = await loadHub();
-      _current = hub;
-      _promise = null;
+      state.current = hub;
+      state.promise = null;
       return hub;
     })();
   }
-  return _promise;
+  return state.promise;
 };
 
 const refreshProviderHub = async (): Promise<ProviderHub> => {

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -6,7 +6,7 @@
   "module": "index.ts",
   "scripts": {
     "test": "bun test",
-    "build": "bun build index.ts --target=bun --outdir ./dist"
+    "build": "bun build index.ts --target=bun --outdir ./dist --metafile=./dist/meta.json --metafile-md=./dist/meta.md"
   },
   "devDependencies": {
     "@types/bun": "catalog:types"


### PR DESCRIPTION
Problem
- top-level await blocks module import during development
- hot reload causes state loss in Bun environment

Solution
- replace top-level await with lazy initialization
- use globalThis for state persistence across reloads
- maintain existing API compatibility

Changes
- add lazy loading to config, database, and llm packages
- implement globalThis state management
- add component tests
- update build scripts